### PR TITLE
refactor: use emit.forEach instead of internal events

### DIFF
--- a/lib/counter/bloc/counter_event.dart
+++ b/lib/counter/bloc/counter_event.dart
@@ -15,15 +15,3 @@ class CounterIncrementPressed extends CounterEvent {
 class CounterDecrementPressed extends CounterEvent {
   const CounterDecrementPressed();
 }
-
-class _CounterCountChanged extends CounterEvent {
-  const _CounterCountChanged(this.count);
-
-  final int count;
-}
-
-class _CounterConnectionStateChanged extends CounterEvent {
-  const _CounterConnectionStateChanged(this.state);
-
-  final ConnectionState state;
-}


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

The Bloc `CounterBloc` uses internal events for stream handling instead of the recommended `emit.forEach` call.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
